### PR TITLE
Allow bigints as args for inputs and outputs

### DIFF
--- a/packages/cashscript/src/interfaces.ts
+++ b/packages/cashscript/src/interfaces.ts
@@ -7,6 +7,12 @@ export interface Utxo {
   satoshis: number;
 }
 
+export interface ProvidedUtxo {
+  txid: string;
+  vout: number;
+  satoshis: number | bigint;
+}
+
 export interface SignableUtxo extends Utxo {
   template: SignatureTemplate;
 }
@@ -17,7 +23,7 @@ export function isSignableUtxo(utxo: Utxo): utxo is SignableUtxo {
 
 export interface Recipient {
   to: string;
-  amount: number;
+  amount: number | bigint;
 }
 
 export interface Output {

--- a/packages/cashscript/src/utils.ts
+++ b/packages/cashscript/src/utils.ts
@@ -44,7 +44,7 @@ import {
 // ////////// PARAMETER VALIDATION ////////////////////////////////////////////
 export function validateRecipient(recipient: Recipient): void {
   if (recipient.amount < DUST_LIMIT) {
-    throw new OutputSatoshisTooSmallError(recipient.amount);
+    throw new OutputSatoshisTooSmallError(Number(recipient.amount));
   }
 }
 


### PR DESCRIPTION
Initially the request was to use bigint everywhere. But there's a few issues:

1. It's hard to do this in a non-breaking way, and I don't know if it's worth it to do a breaking release for something like this.
2. Fee calculation is a delicate part of the code that would need to be fully refactored to work with bigints, which I doubt would be worth the benefit.

So I ended up with only a very small update that allows users to provide inputs and outputs with bigints rather than numbers.