### PR TITLE
BugFix: Supported template, scenario bytecode and decodeInt

### DIFF
--- a/packages/cashscript/src/LibauthTemplate.ts
+++ b/packages/cashscript/src/LibauthTemplate.ts
@@ -56,7 +56,7 @@ export const buildTemplate = async ({
     $schema: 'https://ide.bitauth.com/authentication-template-v0.schema.json',
     description: 'Imported from cashscript',
     name: 'CashScript Generated Debugging Template',
-    supported: ['BCH_2023_05'],
+    supported: ['BCH_2025_05'],
     version: 0,
     entities: generateTemplateEntities(contract.artifact, transaction.abiFunction, transaction.encodedFunctionArgs),
     scripts: generateTemplateScripts(

--- a/packages/cashscript/src/advanced/LibauthTemplate.ts
+++ b/packages/cashscript/src/advanced/LibauthTemplate.ts
@@ -549,6 +549,20 @@ export const getLibauthTemplates = (
     }
   }
 
+  const scenarioKeys = Object.keys(finalTemplate.scenarios);
+  const lastScenarioKey = scenarioKeys[scenarioKeys.length - 1];
+  const lastScenarioBytecode = finalTemplate.scenarios[lastScenarioKey]?.data?.bytecode;
+
+  if (lastScenarioBytecode) {
+    for (let i = 0; i < scenarioKeys.length; i++) {
+      const scenarioIdentifier = scenarioKeys[i];
+      const scenario = finalTemplate.scenarios[scenarioIdentifier];
+      if (!scenario.data) { scenario.data = {}; }
+      if (!scenario.data.bytecode) { scenario.data.bytecode = {}; }
+      scenario.data.bytecode = { ...lastScenarioBytecode, ...scenario.data.bytecode };
+    }
+  }
+
   return finalTemplate;
 };
 

--- a/packages/cashscript/src/advanced/LibauthTemplate.ts
+++ b/packages/cashscript/src/advanced/LibauthTemplate.ts
@@ -369,7 +369,7 @@ export const getLibauthTemplates = (
     $schema: 'https://ide.bitauth.com/authentication-template-v0.schema.json',
     description: 'Imported from cashscript',
     name: 'CashScript Generated Debugging Template',
-    supported: ['BCH_2023_05'],
+    supported: ['BCH_2025_05'],
     version: 0,
     entities: {},
     scripts: {},
@@ -535,6 +535,18 @@ export const getLibauthTemplates = (
       }
     }
 
+  }
+
+  // Merge data.bytecode from previous scenarios
+  for (const [scenarioIdentifier, scenario] of Object.entries(finalTemplate.scenarios)) {
+    if (scenario.data && scenario.data.bytecode) {
+      const previousIndex = Object.keys(finalTemplate.scenarios).indexOf(scenarioIdentifier) - 1;
+      if (previousIndex >= 0) {
+        const previousScenarioIdentifier = Object.keys(finalTemplate.scenarios)[previousIndex];
+        const previousBytecode = finalTemplate.scenarios[previousScenarioIdentifier]?.data?.bytecode;
+        scenario.data.bytecode = { ...previousBytecode, ...scenario.data.bytecode };
+      }
+    }
   }
 
   return finalTemplate;

--- a/packages/utils/src/data.ts
+++ b/packages/utils/src/data.ts
@@ -26,9 +26,8 @@ export function encodeInt(int: bigint): Uint8Array {
   return bigIntToVmNumber(int);
 }
 
-export function decodeInt(encodedInt: Uint8Array, maxLength: number = 8): bigint {
-  const options = { maximumVmNumberByteLength: maxLength };
-  const result = vmNumberToBigInt(encodedInt, options);
+export function decodeInt(encodedInt: Uint8Array): bigint {
+  const result = vmNumberToBigInt(encodedInt);
 
   if (isVmNumberError(result)) {
     throw new Error(result);


### PR DESCRIPTION
1. Adds `supported: ['BCH_2025_05'],` in the template generation

2. It seems like when scenarios are created, the data from the previous scenario is required in some cases. The active scenario needs to be aware of other variables.


The Error:
> Cannot generate scenario "foo_call_evaluate": Failed compilation of source output at index 1: Identifier "base_category" refers to a WalletData, but "base_category" was not provided in the CompilationData "bytecode". Failed compilation of source output at index 2: Identifier "base_category" refers to a WalletData, but "base_category" was not provided in the CompilationData "bytecode". Failed compilation of transaction output at index 1: Identifier "base_category" refers to a WalletData, but "base_category" was not provided in the CompilationData "bytecode".

**How to reproduce?**

`Foo.cash`
```solidity
pragma cashscript ^0.11.0;

contract Foo() {
  function test(){
    require(2==2);
  }
}
```
`Bar.cash`
```solidity
pragma cashscript ^0.11.0;

contract Bar(bytes32 baseCategory) {
    function call(bytes32 categoryFromArg){
        require(baseCategory==categoryFromArg);
  }
}
```

`Baz.cash`
```solidity
pragma cashscript ^0.11.0;

contract Baz(bytes32 baseCategory) {
    function call(bytes32 categoryFromArg){
        require(baseCategory==categoryFromArg);
  }
}
```

Note: Upon testing, I observed that only the `bytes` or `bytesx` types have this requirement. The `int` and `pubkey` types do not require this merge. The existence of unused variables in the scenario does not cause an issue, as
`scenario.data.bytecode = { ...previousBytecode, ...scenario.data.bytecode };`  overrides conflicts.

[BitauthUri Before and After Fix](https://gist.github.com/kiok46/e8b6fb2cf31d6c2818bd77cc2b95c0a2)

3. [decodeInt](https://github.com/CashScript/cashscript/blob/next/packages/utils/src/data.ts#L29) still has `number = 8` as maxLength default, it shouldn't be anything. This creates `Error: Failed to decode VM Number: overflows VM Number range.` Removing the optional parameter creates some errors so it probably needs more research or a much higher number needs to be added. After talking to @mr-zwets I am including that in this PR as well.