### PR TITLE
Track UTXOs in MockNetworkProvider

### DIFF
--- a/packages/cashscript/src/utils.ts
+++ b/packages/cashscript/src/utils.ts
@@ -33,6 +33,7 @@ import {
   TokenDetails,
   AddressType,
   UnlockableUtxo,
+  LibauthTokenDetails,
 } from './interfaces.js';
 import { VERSION_SIZE, LOCKTIME_SIZE } from './constants.js';
 import {
@@ -113,13 +114,17 @@ export function libauthOutputToCashScriptOutput(output: LibauthOutput): Output {
   return {
     to: output.lockingBytecode,
     amount: output.valueSatoshis,
-    token: output.token && {
-      ...output.token,
-      category: binToHex(output.token.category),
-      nft: output.token.nft && {
-        ...output.token.nft,
-        commitment: binToHex(output.token.nft.commitment),
-      },
+    token: output.token && libauthTokenDetailsToCashScriptTokenDetails(output.token),
+  };
+}
+
+export function libauthTokenDetailsToCashScriptTokenDetails(token: LibauthTokenDetails): TokenDetails {
+  return {
+    ...token,
+    category: binToHex(token.category),
+    nft: token.nft && {
+      ...token.nft,
+      commitment: binToHex(token.nft.commitment),
     },
   };
 }

--- a/packages/cashscript/test/e2e/network/MockNetworkProvider.test.ts
+++ b/packages/cashscript/test/e2e/network/MockNetworkProvider.test.ts
@@ -65,7 +65,7 @@ describeOrSkip(!process.env.TESTS_USE_CHIPNET, 'MockNetworkProvider', () => {
       // utxo should be added to bob
       expect(await provider.getUtxos(bobAddress)).toHaveLength(1);
 
-      await expect(provider.sendRawTransaction(tx)).rejects.toThrow('txn-mempool-conflict');
+      await expect(provider.sendRawTransaction(tx)).rejects.toThrow('already submitted');
     });
   });
 


### PR DESCRIPTION
MockNetworkProvider now keeps track of utxo set - removes spent utxos and adds newly created